### PR TITLE
Minor Update 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /venv/
 .env
+__pycache__/

--- a/app.py
+++ b/app.py
@@ -159,7 +159,7 @@ def get_chat_completion(character_description, event, event_effects, context, in
             print(system_instructions)
             print(f"CONTEXT:{context}\n\nINCOMPLETE SENTENCE:{incomplete_sentence}")
 
-            answer = json.loads(response.choices[0].json())['message']['content']
+            answer = json.loads(response.choices[0].model_dump_json())['message']['content']            
             return answer
         except Exception as e:
             return get_chat_completion(context=context, incomplete_sentence=incomplete_sentence, model=model,


### PR DESCRIPTION
Modified gitignore for pycache. Fixed issue:  PydanticDeprecatedSince20: The json method is deprecated; use model_dump_json instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at